### PR TITLE
Add support for webpack 4

### DIFF
--- a/lib/analyze-bundle.js
+++ b/lib/analyze-bundle.js
@@ -48,7 +48,7 @@ const outputDir = getOutputDir();
 const modIdsFromComments = comments.filter((c) => {
   if (c.type === "Block" && c.value.match(/^ [0-9]+ $/)) {
     const x = code.substr(c.end + 1, 1);
-    return x === "," || x === "[" || x.match(/[0-9]/) || code.substr(c.end + 1, 8) === "function";
+    return x === "," || x === "[" || x.match(/[0-9]/) || code.substr(c.end + 1, 8) === "function" || code.substr(c.end, 8) === "function";
   }
 });
 


### PR DESCRIPTION
With webpack 4, the output now looks like this : 

/* 3 */function(e,t,n){var r=n(73);e.exports=function(e,t,n){var a=null==e?void 0:r(e,t);return void 0===a?n:a}},

In that case, I can see that code.substr(c.end + 1, 8) is "unction(",